### PR TITLE
map

### DIFF
--- a/er_launch/launch/milestone_1.launch
+++ b/er_launch/launch/milestone_1.launch
@@ -36,11 +36,4 @@
 
   <include file="$(find rplidar_ros)/launch/rplidar.launch" />
 
-  <node name="maze_map_node" pkg="ras_maze_map" type="ras_maze_map_node" output="screen">
-    <param name="map_file" value="$(find ras_maze_map)/maps/lab_maze_2018.txt" />
-  </node>
-
-  <node name="slam" pkg="er_navigation" type="er_slam_node" output="screen">
-    <param name="map_file" value="$(find ras_maze_map)/maps/lab_maze_2018.txt" />
-  </node>
 </launch>

--- a/er_launch/launch/milestone_1.launch
+++ b/er_launch/launch/milestone_1.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <node pkg="tf2_ros" type="static_transform_publisher" name="lidar_tf" args="0 0 0 0 0 0 1 base_link laser" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="lidar_tf" args="0.03 0 0 3.1415 0 0 base_link laser" />
 
   <node pkg="tf2_ros" type="static_transform_publisher" name="odom_tf" args="0 0 0 0 0 0 1 map odom" />
 

--- a/er_launch/launch/robot.launch
+++ b/er_launch/launch/robot.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <node pkg="tf2_ros" type="static_transform_publisher" name="lidar_tf" args="0 0 0 0 0 0 1 base_link laser" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="lidar_tf" args="0.03 0 0 3.1415 0 0 base_link laser" />
 
   <node pkg="tf2_ros" type="static_transform_publisher" name="odom_tf" args="0 0 0 0 0 0 1 map odom" />
 

--- a/er_navigation/CMakeLists.txt
+++ b/er_navigation/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(er_navigation)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  nav_msgs
+)
+
+add_compile_options(-std=c++11)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp nav_msgs
+)
+
+include_directories(
+  include ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(er_slam_node src/er_slam_node.cpp src/map_reader.cpp)
+
+add_dependencies(er_slam_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(er_slam_node ${catkin_LIBRARIES})

--- a/er_navigation/CMakeLists.txt
+++ b/er_navigation/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(
   include ${catkin_INCLUDE_DIRS}
 )
 
-add_executable(er_slam_node src/er_slam_node.cpp src/map_reader.cpp)
+add_executable(er_slam_node src/er_slam_node.cpp src/map_reader.cpp src/occupancy_grid_utils.cpp)
 
 add_dependencies(er_slam_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 

--- a/er_navigation/include/er_slam_node.h
+++ b/er_navigation/include/er_slam_node.h
@@ -1,0 +1,23 @@
+#ifndef ER_SLAM_NODE_H
+#define ER_SLAM_NODE_H
+
+#include "map_reader.h"
+
+#include "ros/ros.h"
+#include "nav_msgs/Odometry.h"
+#include "nav_msgs/OccupancyGrid.h"
+
+#include <string>
+
+class SLAMNode {
+public:
+  SLAMNode();
+  ~SLAMNode();
+
+  void run_node();
+
+private:
+};
+
+
+#endif

--- a/er_navigation/include/er_slam_node.h
+++ b/er_navigation/include/er_slam_node.h
@@ -17,6 +17,7 @@ public:
   void run_node();
 
 private:
+  ros::NodeHandle nh_;
 };
 
 

--- a/er_navigation/include/er_slam_node.h
+++ b/er_navigation/include/er_slam_node.h
@@ -17,7 +17,13 @@ public:
   void run_node();
 
 private:
+  void init_node();
+
   ros::NodeHandle nh_;
+  ros::Publisher map_publisher_;
+  ros::Rate loop_rate_;
+
+  nav_msgs::OccupancyGrid current_map_;
 };
 
 

--- a/er_navigation/include/map_reader.h
+++ b/er_navigation/include/map_reader.h
@@ -1,6 +1,8 @@
 #ifndef MAP_READER_H
 #define MAP_READER_H
 
+#include "occupancy_grid_utils.h"
+
 #include "ros/ros.h"
 #include "nav_msgs/OccupancyGrid.h"
 

--- a/er_navigation/include/map_reader.h
+++ b/er_navigation/include/map_reader.h
@@ -1,0 +1,30 @@
+#ifndef MAP_READER_H
+#define MAP_READER_H
+
+#include "ros/ros.h"
+#include "nav_msgs/OccupancyGrid.h"
+
+#include <cmath>
+#include <string>
+#include <fstream>
+#include <sstream>
+
+class MapReader {
+public:
+  MapReader(std::string path_to_map);
+  ~MapReader();
+
+  nav_msgs::OccupancyGrid occupancy_grid() const;
+
+private:
+  struct Wall {
+    double x_start, x_end, y_start, y_end;
+
+    Wall(double xs, double xe, double ys, double ye) : x_start(xs), x_end(xe), y_start(ys), y_end(ye) {};
+  };
+
+  std::vector<Wall> walls;
+};
+
+
+#endif

--- a/er_navigation/include/occupancy_grid_utils.h
+++ b/er_navigation/include/occupancy_grid_utils.h
@@ -1,0 +1,11 @@
+#ifndef OCCUPANCY_GRID_UTILS_H
+#define OCCUPANCY_GRID_UTILS_H
+
+#include "ros/ros.h"
+#include "nav_msgs/OccupancyGrid.h"
+
+#include <cmath>
+
+void bresenham_line(nav_msgs::OccupancyGrid &occupancy_grid, double x_start, double x_end, double y_start, double y_end);
+
+#endif

--- a/er_navigation/include/occupancy_grid_utils.h
+++ b/er_navigation/include/occupancy_grid_utils.h
@@ -6,6 +6,10 @@
 
 #include <cmath>
 
-void bresenham_line(nav_msgs::OccupancyGrid &occupancy_grid, double x_start, double x_end, double y_start, double y_end);
+// TODO: add namespace
+
+void draw_line(nav_msgs::OccupancyGrid &occupancy_grid, double x_start, double x_end, double y_start, double y_end, int8_t value=100);
+int8_t&  at(nav_msgs::OccupancyGrid &occupancy_grid, int x, int y);
+int sign(int x);
 
 #endif

--- a/er_navigation/package.xml
+++ b/er_navigation/package.xml
@@ -20,7 +20,7 @@
   <depend>nav_msgs</depend>
   <depend>roscpp</depend>
   <depend>tf2</depend>
-
+  
   <export>
 
   </export>

--- a/er_navigation/package.xml
+++ b/er_navigation/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>er_navigation</name>
+  <version>0.0.1</version>
+  <description>This package performs mapping, localization and low level path planning.</description>
+
+  <author email="leonardb@kth.se">Leonard Bruns</author>
+  <author email="fradesjo@kth.se">Fanny Radesjö</author>
+  <author email="gupett@kth.se">Gustav Pettersson</author>
+  <author email="tomaszuk@kth.se">Michal Tomaszuk</author>
+
+  <maintainer email="leonardb@kth.se">Leonard Bruns</maintainer>
+  <maintainer email="fradesjo@kth.se">Fanny Radesjö</maintainer>
+  <maintainer email="gupett@kth.se">Gustav Pettersson</maintainer>
+  <maintainer email="tomaszuk@kth.se">Michal Tomaszuk</maintainer>
+
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>nav_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>tf2</depend>
+
+  <export>
+
+  </export>
+</package>

--- a/er_navigation/src/er_slam_node.cpp
+++ b/er_navigation/src/er_slam_node.cpp
@@ -1,0 +1,28 @@
+#include "er_slam_node.h"
+
+SLAMNode::SLAMNode() {
+
+}
+
+SLAMNode::~SLAMNode() {
+
+}
+
+void SLAMNode::run_node() {
+  std::string map_path;
+  ros::param::param<std::string>("~map_file", map_path, "");
+
+  MapReader map_reader(map_path);
+
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "er_slam_node");
+
+  SLAMNode slam_node;
+
+  slam_node.run_node();
+
+  return 0;
+}

--- a/er_navigation/src/er_slam_node.cpp
+++ b/er_navigation/src/er_slam_node.cpp
@@ -1,6 +1,6 @@
 #include "er_slam_node.h"
 
-SLAMNode::SLAMNode() {
+SLAMNode::SLAMNode() : nh_() {
 
 }
 
@@ -14,6 +14,15 @@ void SLAMNode::run_node() {
 
   MapReader map_reader(map_path);
 
+  ros::Publisher map_publisher = nh_.advertise<nav_msgs::OccupancyGrid>("/occupancy_grid", 1);
+
+  ros::Rate loop_rate(10);
+
+  while(ros::ok()) {
+    map_publisher.publish(map_reader.occupancy_grid());
+
+    loop_rate.sleep();
+  }
 }
 
 int main(int argc, char **argv)

--- a/er_navigation/src/er_slam_node.cpp
+++ b/er_navigation/src/er_slam_node.cpp
@@ -1,6 +1,6 @@
 #include "er_slam_node.h"
 
-SLAMNode::SLAMNode() : nh_() {
+SLAMNode::SLAMNode() : nh_(), loop_rate_(10) {
 
 }
 
@@ -8,20 +8,24 @@ SLAMNode::~SLAMNode() {
 
 }
 
-void SLAMNode::run_node() {
+void SLAMNode::init_node() {
   std::string map_path;
   ros::param::param<std::string>("~map_file", map_path, "");
 
   MapReader map_reader(map_path);
 
-  ros::Publisher map_publisher = nh_.advertise<nav_msgs::OccupancyGrid>("/occupancy_grid", 1);
+  map_publisher_ = nh_.advertise<nav_msgs::OccupancyGrid>("/occupancy_grid", 1);
 
-  ros::Rate loop_rate(10);
+  current_map_ = map_reader.occupancy_grid();
+}
+
+void SLAMNode::run_node() {
+  init_node();
 
   while(ros::ok()) {
-    map_publisher.publish(map_reader.occupancy_grid());
+    map_publisher_.publish(current_map_);
 
-    loop_rate.sleep();
+    loop_rate_.sleep();
   }
 }
 

--- a/er_navigation/src/map_reader.cpp
+++ b/er_navigation/src/map_reader.cpp
@@ -6,27 +6,33 @@ MapReader::MapReader(std::string path_to_map) {
   std::ifstream ifs;
   double xstart, xend, ystart, yend;
   std::string line;
-  ifs.open(path_to_map);
 
-  while(!ifs.eof()) {
-    std::getline(ifs, line);
+  try {
+    ifs.open(path_to_map);
+    while(!ifs.eof()) {
+      if (ifs.fail()) {
+        throw 1;
+      }
+      std::getline(ifs, line);
 
-    // skip comments
-    if(line[0] == '#' or ifs.eof())
-      continue;
+      // skip comments
+      if(line[0] == '#' or ifs.eof())
+        continue;
 
-    // read the coordinates of the wall in the predefined format
-    std::istringstream iss(line);
-    iss >> xstart >> ystart >> xend >> yend;
+      // read the coordinates of the wall in the predefined format
+      std::istringstream iss(line);
+      iss >> xstart >> ystart >> xend >> yend;
 
-    // store all these coordinates inside the walls vector
-    walls.emplace_back(xstart, xend, ystart, yend);
+      // store all these coordinates inside the walls vector
+      walls.emplace_back(xstart, xend, ystart, yend);
 
-    ROS_DEBUG_STREAM(xstart << " " << ystart << " " << xend << " " << yend);
+      ROS_DEBUG_STREAM(xstart << " " << ystart << " " << xend << " " << yend);
+    }
+    ROS_INFO_STREAM("Map succesfully read.");
   }
-
-
-  ROS_INFO_STREAM("Map succesfully read.");
+  catch (...) {
+    ROS_ERROR("Unknown error when reading the map, check the file path");
+  }
 }
 
 MapReader::~MapReader() {
@@ -34,5 +40,7 @@ MapReader::~MapReader() {
 }
 
 nav_msgs::OccupancyGrid MapReader::occupancy_grid() const {
-  
+  nav_msgs::OccupancyGrid occupancy_grid_msg = nav_msgs::OccupancyGrid();
+
+  return occupancy_grid_msg;
 }

--- a/er_navigation/src/map_reader.cpp
+++ b/er_navigation/src/map_reader.cpp
@@ -42,13 +42,29 @@ MapReader::~MapReader() {
 nav_msgs::OccupancyGrid MapReader::occupancy_grid() const {
   nav_msgs::OccupancyGrid occupancy_grid_msg = nav_msgs::OccupancyGrid();
 
-  // TODO: determine from wall values
-  double width = 3.0;
-  double height = 3.0;
-  double resolution = 0.03;
+  double max_x = 0;
+  double max_y = 0;
+  for(auto it = walls.begin(); it != walls.end(); ++it) {
+    if(it->x_start > max_x) {
+      max_x = it->x_start;
+    }
+    if(it->x_end > max_x) {
+      max_x = it->x_end;
+    }
+    if(it->y_start > max_y) {
+      max_y = it->y_start;
+    }
+    if(it->y_end > max_y) {
+        max_y = it->y_end;
+    }
+  }
+
+  double width = max_x;
+  double height = max_y;
+  double resolution = 0.02;
 
 
-  double margin = 3.0;
+  double margin = 0.5;
   int8_t unknown_value = 5;
 
   occupancy_grid_msg.header.frame_id = "/map";

--- a/er_navigation/src/map_reader.cpp
+++ b/er_navigation/src/map_reader.cpp
@@ -41,22 +41,29 @@ MapReader::~MapReader() {
 
 nav_msgs::OccupancyGrid MapReader::occupancy_grid() const {
   nav_msgs::OccupancyGrid occupancy_grid_msg = nav_msgs::OccupancyGrid();
+
+  // TODO: determine from wall values
   double width = 3.0;
   double height = 3.0;
   double resolution = 0.03;
+
+
+  double margin = 3.0;
   int8_t unknown_value = 5;
 
   occupancy_grid_msg.header.frame_id = "/map";
 
   occupancy_grid_msg.info.resolution = resolution;
-  occupancy_grid_msg.info.width = width/resolution;
-  occupancy_grid_msg.info.height = height/resolution;
+  occupancy_grid_msg.info.width = (width+2*margin)/resolution;
+  occupancy_grid_msg.info.height = (height+2*margin)/resolution;
 
+  occupancy_grid_msg.info.origin.position.x = -margin;
+  occupancy_grid_msg.info.origin.position.y = -margin;
 
   occupancy_grid_msg.data = std::vector<int8_t>(occupancy_grid_msg.info.width * occupancy_grid_msg.info.height, unknown_value);
 
   for(auto it = walls.begin(); it != walls.end(); ++it) {
-    bresenham_line(occupancy_grid_msg, it->x_start, it->x_end, it->y_start, it->y_end);
+    draw_line(occupancy_grid_msg, it->x_start+margin, it->x_end+margin, it->y_start+margin, it->y_end+margin);
   }
 
   return occupancy_grid_msg;

--- a/er_navigation/src/map_reader.cpp
+++ b/er_navigation/src/map_reader.cpp
@@ -1,0 +1,38 @@
+#include "map_reader.h"
+
+MapReader::MapReader(std::string path_to_map) {
+  ROS_INFO_STREAM("Trying to read map at " << path_to_map);
+
+  std::ifstream ifs;
+  double xstart, xend, ystart, yend;
+  std::string line;
+  ifs.open(path_to_map);
+
+  while(!ifs.eof()) {
+    std::getline(ifs, line);
+
+    // skip comments
+    if(line[0] == '#' or ifs.eof())
+      continue;
+
+    // read the coordinates of the wall in the predefined format
+    std::istringstream iss(line);
+    iss >> xstart >> ystart >> xend >> yend;
+
+    // store all these coordinates inside the walls vector
+    walls.emplace_back(xstart, xend, ystart, yend);
+
+    ROS_DEBUG_STREAM(xstart << " " << ystart << " " << xend << " " << yend);
+  }
+
+
+  ROS_INFO_STREAM("Map succesfully read.");
+}
+
+MapReader::~MapReader() {
+
+}
+
+nav_msgs::OccupancyGrid MapReader::occupancy_grid() const {
+  
+}

--- a/er_navigation/src/map_reader.cpp
+++ b/er_navigation/src/map_reader.cpp
@@ -41,6 +41,19 @@ MapReader::~MapReader() {
 
 nav_msgs::OccupancyGrid MapReader::occupancy_grid() const {
   nav_msgs::OccupancyGrid occupancy_grid_msg = nav_msgs::OccupancyGrid();
+  double width = 3.0;
+  double height = 3.0;
+  double resolution = 0.03;
+  int8_t unknown_value = 5;
+
+  occupancy_grid_msg.header.frame_id = "/map";
+
+  occupancy_grid_msg.info.resolution = resolution;
+  occupancy_grid_msg.info.width = width/resolution;
+  occupancy_grid_msg.info.height = height/resolution;
+
+
+  occupancy_grid_msg.data = std::vector<int8_t>(occupancy_grid_msg.info.width * occupancy_grid_msg.info.height, unknown_value);
 
   for(auto it = walls.begin(); it != walls.end(); ++it) {
     bresenham_line(occupancy_grid_msg, it->x_start, it->x_end, it->y_start, it->y_end);

--- a/er_navigation/src/map_reader.cpp
+++ b/er_navigation/src/map_reader.cpp
@@ -42,5 +42,9 @@ MapReader::~MapReader() {
 nav_msgs::OccupancyGrid MapReader::occupancy_grid() const {
   nav_msgs::OccupancyGrid occupancy_grid_msg = nav_msgs::OccupancyGrid();
 
+  for(auto it = walls.begin(); it != walls.end(); ++it) {
+    bresenham_line(occupancy_grid_msg, it->x_start, it->x_end, it->y_start, it->y_end);
+  }
+
   return occupancy_grid_msg;
 }

--- a/er_navigation/src/occupancy_grid_utils.cpp
+++ b/er_navigation/src/occupancy_grid_utils.cpp
@@ -1,0 +1,5 @@
+#include "occupancy_grid_utils.h"
+
+void bresenham_line(nav_msgs::OccupancyGrid &occupancy_grid, double x_start, double x_end, double y_start, double y_end) {
+
+}

--- a/er_navigation/src/occupancy_grid_utils.cpp
+++ b/er_navigation/src/occupancy_grid_utils.cpp
@@ -3,3 +3,7 @@
 void bresenham_line(nav_msgs::OccupancyGrid &occupancy_grid, double x_start, double x_end, double y_start, double y_end) {
 
 }
+
+int8_t&  at(nav_msgs::OccupancyGrid &occupancy_grid, int x, int y) {
+  occupancy_grid.data[y*occupancy_grid.info.width + x];
+}

--- a/er_navigation/src/occupancy_grid_utils.cpp
+++ b/er_navigation/src/occupancy_grid_utils.cpp
@@ -1,9 +1,31 @@
 #include "occupancy_grid_utils.h"
 
-void bresenham_line(nav_msgs::OccupancyGrid &occupancy_grid, double x_start, double x_end, double y_start, double y_end) {
+void draw_line(nav_msgs::OccupancyGrid &occupancy_grid, double x_start, double x_end, double y_start, double y_end, int8_t value) {
+  // I made this algorithm up myself, probably doing something like this would be much more efficient
+  // but requires much more code: https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
+  x_start /= occupancy_grid.info.resolution;
+  x_end /= occupancy_grid.info.resolution;
+  y_start /= occupancy_grid.info.resolution;
+  y_end /= occupancy_grid.info.resolution;
+  double delta_x = x_end-x_start;
+  double delta_y = y_end-y_start;
 
+  int steps = round(sqrt(pow(delta_x, 2) + pow(delta_y,2))*2+1);
+  double x = x_start;
+  double y = y_start;
+
+  for(int i=0; i<=steps; ++i) {
+    x = x_start + delta_x * i / (double)steps;
+    y = y_start + delta_y * i / (double)steps;
+    int8_t& data = at(occupancy_grid, round(x), round(y));
+    data = value;
+  }
 }
 
 int8_t&  at(nav_msgs::OccupancyGrid &occupancy_grid, int x, int y) {
   occupancy_grid.data[y*occupancy_grid.info.width + x];
+}
+
+int sign(int x) {
+  return x>=0 ? 1 : -1;
 }

--- a/er_wheels/CMakeLists.txt
+++ b/er_wheels/CMakeLists.txt
@@ -25,9 +25,9 @@ add_executable(er_cartesian_motor_controller_node src/er_cartesian_motor_control
 add_executable(er_motor_controller_node src/er_motor_controller_node.cpp)
 add_executable(er_wheel_odometry_node src/er_wheel_odometry_node.cpp)
 
-add_dependencies(er_cartesian_motor_controller_node ${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-add_dependencies(er_motor_controller_node ${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-add_dependencies(er_wheel_odometry_node ${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(er_cartesian_motor_controller_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(er_motor_controller_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(er_wheel_odometry_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 
 target_link_libraries(er_cartesian_motor_controller_node ${catkin_LIBRARIES})


### PR DESCRIPTION
This completes MS2.2. ("You can read the map file and turn that into your own map representation and display it along with the position of the robot.")

Map below the reference walls:
![screenshot_20181012_161321](https://user-images.githubusercontent.com/9785832/46874681-09a47d00-ce3a-11e8-89d3-50d0a555981c.png)

Map without the reference walls:
![screenshot_20181012_161336](https://user-images.githubusercontent.com/9785832/46874685-0c06d700-ce3a-11e8-960e-b95aad7c1972.png)

This also adds the slam package, which will later be extended to do both, localization and mapping. That's why I structured the code as it is right now.

Note that for pathplanning the map will be dilated, thus it is no problem that there is a little hole in the middle. For the localization filter, we'll have to check how exactly the lidar will be incorporated if the diagonal/discretized walls make a problem.
