### PR TITLE
[WIP] camera_pointcloud_handler merge after map

### DIFF
--- a/er_launch/launch/robot.launch
+++ b/er_launch/launch/robot.launch
@@ -46,6 +46,7 @@
     <param name="map_file" value="$(find ras_maze_map)/maps/lab_maze_2018.txt" />
   </node>
 
+  <include file="$(find realsense_camera)/launch/sr300_nodelet_rgbd.launch" />
 
   <node name="pointcloud_to_2d_node" pkg="er_perception" type="er_pointcloud_to_2d_node" output="screen">
     <!-- note that the robots wheel axis will be at 0, thus if we position the camera correctly in 3d, ground will be negative (optimally at -wheel_radius)-->

--- a/er_launch/launch/robot.launch
+++ b/er_launch/launch/robot.launch
@@ -2,7 +2,7 @@
 
   <node pkg="tf2_ros" type="static_transform_publisher" name="lidar_tf" args="0.03 0 0 3.1415 0 0 base_link laser" />
 
-  <node pkg="tf2_ros" type="static_transform_publisher" name="camera_tf" args="0.1 0 0.07 0 0.5 0 map camera_link" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="camera_tf" args="0.1 0 0.07 0 0.5 0 base_link camera_link" />
 
   <node pkg="tf2_ros" type="static_transform_publisher" name="odom_tf" args="0 0 0 0 0 0 1 map odom" />
 

--- a/er_launch/launch/robot.launch
+++ b/er_launch/launch/robot.launch
@@ -2,6 +2,8 @@
 
   <node pkg="tf2_ros" type="static_transform_publisher" name="lidar_tf" args="0.03 0 0 3.1415 0 0 base_link laser" />
 
+  <node pkg="tf2_ros" type="static_transform_publisher" name="camera_tf" args="0.1 0 0.07 0 0.5 0 map camera_link" />
+
   <node pkg="tf2_ros" type="static_transform_publisher" name="odom_tf" args="0 0 0 0 0 0 1 map odom" />
 
   <node name="left_motor" pkg="phidgets" type="motor" output="screen" >
@@ -42,5 +44,11 @@
 
   <node name="slam" pkg="er_navigation" type="er_slam_node" output="screen">
     <param name="map_file" value="$(find ras_maze_map)/maps/lab_maze_2018.txt" />
+  </node>
+
+  <node name="pointcloud_to_2d_node" pkg="er_perception" type="er_pointcloud_to_2d_node" output="screen">
+    <!-- note that the robots wheel axis will be at 0, thus if we position the camera correctly in 3d, ground will be negative (optimally at -wheel_radius)-->
+    <param name="min_height" value="-0.03" />
+    <param name="range" value="0.01" />
   </node>
 </launch>

--- a/er_launch/launch/robot.launch
+++ b/er_launch/launch/robot.launch
@@ -46,9 +46,10 @@
     <param name="map_file" value="$(find ras_maze_map)/maps/lab_maze_2018.txt" />
   </node>
 
+
   <node name="pointcloud_to_2d_node" pkg="er_perception" type="er_pointcloud_to_2d_node" output="screen">
     <!-- note that the robots wheel axis will be at 0, thus if we position the camera correctly in 3d, ground will be negative (optimally at -wheel_radius)-->
-    <param name="min_height" value="-0.03" />
-    <param name="range" value="0.01" />
+    <param name="min_height" value="-0.015" />
+    <param name="range" value="0.005" />
   </node>
 </launch>

--- a/er_launch/launch/rosbag.launch
+++ b/er_launch/launch/rosbag.launch
@@ -1,0 +1,7 @@
+<launch>
+
+  <param name="/use_sim_time" value="true"/>
+
+  <include file="$(find er_launch)/launch/robot.launch" />
+
+</launch>

--- a/er_perception/CMakeLists.txt
+++ b/er_perception/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(er_perception)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  sensor_msgs
+  pcl_ros
+  tf2
+)
+
+add_compile_options(-std=c++11)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp sensor_msgs pcl_ros tf2
+)
+
+include_directories(
+  include ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(er_pointcloud_to_2d_node src/er_pointcloud_to_2d_node.cpp)
+
+add_dependencies(er_pointcloud_to_2d_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(er_pointcloud_to_2d_node ${catkin_LIBRARIES})

--- a/er_perception/include/er_pointcloud_to_2d_node.h
+++ b/er_perception/include/er_pointcloud_to_2d_node.h
@@ -4,8 +4,13 @@
 #include "ros/ros.h"
 #include "pcl_ros/transforms.h"
 #include "tf2_ros/transform_listener.h"
+#include "pcl_ros/point_cloud.h"
+#include "pcl/point_types.h"
 
 #include <string>
+#include <cmath>
+
+typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 
 class PointCloudTo2DNode {
 public:
@@ -16,7 +21,7 @@ public:
 
 private:
   void init_node();
-  void pointcloud_cb(const sensor_msgs::PointCloud2::ConstPtr& msg);
+  void pointcloud_cb(const PointCloud::ConstPtr& msg);
 
   // the minimum height to use points
   double min_height_;

--- a/er_perception/include/er_pointcloud_to_2d_node.h
+++ b/er_perception/include/er_pointcloud_to_2d_node.h
@@ -1,0 +1,33 @@
+#ifndef ER_POINTCLOUD_TO_2D_NODE_H
+#define ER_POINTCLOUD_TO_2D_NODE_H
+
+#include "ros/ros.h"
+#include "pcl_ros/transforms.h"
+#include "tf2_ros/transform_listener.h"
+
+#include <string>
+
+class PointCloudTo2DNode {
+public:
+  PointCloudTo2DNode();
+  ~PointCloudTo2DNode();
+
+  void run_node();
+
+private:
+  void init_node();
+  void pointcloud_cb(const sensor_msgs::PointCloud2::ConstPtr& msg);
+
+  // the minimum height to use points
+  double min_height_;
+  // the height above min_height_ in which points will be accumulated
+  double range_;
+
+  ros::NodeHandle nh_;
+  ros::Subscriber pointcloud_subsriber_;
+  ros::Publisher pointcloud_publisher_;
+  tf::TransformListener tf_listener_;
+};
+
+
+#endif

--- a/er_perception/package.xml
+++ b/er_perception/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>er_perception</name>
+  <version>0.0.1</version>
+  <description>This package handles the perception i.e. the camera of the robot.</description>
+
+  <author email="leonardb@kth.se">Leonard Bruns</author>
+  <author email="fradesjo@kth.se">Fanny Radesjö</author>
+  <author email="gupett@kth.se">Gustav Pettersson</author>
+  <author email="tomaszuk@kth.se">Michal Tomaszuk</author>
+
+  <maintainer email="leonardb@kth.se">Leonard Bruns</maintainer>
+  <maintainer email="fradesjo@kth.se">Fanny Radesjö</maintainer>
+  <maintainer email="gupett@kth.se">Gustav Pettersson</maintainer>
+  <maintainer email="tomaszuk@kth.se">Michal Tomaszuk</maintainer>
+
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>pcl_ros</depend>
+
+
+  <export>
+
+  </export>
+</package>

--- a/er_perception/src/er_pointcloud_to_2d_node.cpp
+++ b/er_perception/src/er_pointcloud_to_2d_node.cpp
@@ -1,0 +1,53 @@
+#include "er_pointcloud_to_2d_node.h"
+
+PointCloudTo2DNode::PointCloudTo2DNode() : nh_() {
+
+}
+
+PointCloudTo2DNode::~PointCloudTo2DNode() {
+
+}
+
+void PointCloudTo2DNode::pointcloud_cb(const sensor_msgs::PointCloud2::ConstPtr& msg) {
+  ROS_INFO("Received pointcloud");
+
+  sensor_msgs::PointCloud2 transformed_pointcloud;
+
+
+
+  pcl_ros::transformPointCloud("/map", *msg, transformed_pointcloud, tf_listener_);
+  transformed_pointcloud.height = transformed_pointcloud.height * transformed_pointcloud.width;
+  transformed_pointcloud.width = 1;
+
+  pointcloud_publisher_.publish(transformed_pointcloud);
+}
+
+void PointCloudTo2DNode::init_node() {
+  std::string camera_pointcloud_topic;
+  std::string out_pointcloud_topic;
+  ros::param::param<double>("~min_height", min_height_, 0);
+  ros::param::param<double>("~range", range_, 0.01);
+  ros::param::param<std::string>("~camera_pointcloud_topic", camera_pointcloud_topic, "/camera/depth/points");
+  ros::param::param<std::string>("~out_pointcloud_topic", out_pointcloud_topic, "/camera/pointcloud_2d");
+
+
+  pointcloud_subsriber_ = nh_.subscribe<sensor_msgs::PointCloud2>(camera_pointcloud_topic, 1, &PointCloudTo2DNode::pointcloud_cb, this);
+  pointcloud_publisher_ = nh_.advertise<sensor_msgs::PointCloud2>(out_pointcloud_topic, 1);
+}
+
+void PointCloudTo2DNode::run_node() {
+  init_node();
+
+  ros::spin();
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "er_slam_node");
+
+  PointCloudTo2DNode pointcloud_to_2d_node;
+
+  pointcloud_to_2d_node.run_node();
+
+  return 0;
+}


### PR DESCRIPTION
[WIP] Still has to be tested on the robot, only tested on rosbag so far

This adds a node which will remove the ground from the RGBD pointcloud and generates a 2d point cloud, which is easy to use for obstacle detection and mapping of batteries and obstacles.

The basic idea of this is displayed below, the white stripe (which can be adjusted with rosparams) is what will end up in the published message)
![screenshot_20181012_185431](https://user-images.githubusercontent.com/9785832/46884750-38c8e780-ce56-11e8-8b5f-4919ff34beb6.png)

This shows the resulting message (green) based on the received pointcloud (white)
![screenshot_20181012_192622](https://user-images.githubusercontent.com/9785832/46884754-3a92ab00-ce56-11e8-86c4-895d4843ab23.png)

This shows only the resulting pointcloud as it can be used for object detection and mapping.
![screenshot_20181012_192707](https://user-images.githubusercontent.com/9785832/46884759-3e263200-ce56-11e8-9a98-8bc28940a440.png)
